### PR TITLE
Switch back to npm for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Publish packages to npm
         run: |
           npm --version
-          npm publish
+          npm publish --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,5 +27,5 @@ jobs:
         run: YARN_ENABLE_COLORS=true yarn install
       - name: Publish packages to npm
         run: |
-          yarn --version
-          yarn npm publish
+          npm --version
+          npm publish


### PR DESCRIPTION
yarn publishing is missing the transparency log on the npm registry site.